### PR TITLE
Provide a Logger to user-defined Groovy recipes

### DIFF
--- a/src/main/resources/EnvironmentBuilder.groovy
+++ b/src/main/resources/EnvironmentBuilder.groovy
@@ -6,6 +6,8 @@ import org.cloudifysource.dsl.context.ServiceInstance
 
 import org.cloudifysource.utilitydomain.context.ServiceContextFactory
 
+import java.util.logging.Logger
+
 public class EnvironmentBuilder {
 
     private static def NAME_VALUE_KEYWORD = "NAME_VALUE_TO_PARSE"
@@ -25,6 +27,7 @@ public class EnvironmentBuilder {
         Binding binding = new Binding()
         //set the context variable
         binding.setVariable("context", context)
+        binding.setVariable("logger", Logger.getLogger("${context.serviceName}-stdout"))
         
         if(argsMap != null && !argsMap.isEmpty()) {
             buildEnvForGroovy(argsMap, binding)


### PR DESCRIPTION
Benefits:
* Allow recipes writers to use a modern (configurable) logging system instead of basic println ;)
* Finally having traces for custom commands (and [add|remove]_[target|source] lifecycle operations)