### PR TITLE
Update CloudifyExecutorUtils.groovy

### DIFF
--- a/src/main/resources/CloudifyExecutorUtils.groovy
+++ b/src/main/resources/CloudifyExecutorUtils.groovy
@@ -83,8 +83,13 @@ public class CloudifyExecutorUtils {
         if(scriptExitValue) {
             throw new RuntimeException("Error executing the script ${script} (return code: $scriptExitValue)")
         } else {
-            println "sh result is: "+ processResult != null ? processResult.result:null
-            return processResult != null ? processResult.result : null
+            if (processResult != null){
+				println "sh result is: "+ processResult.result
+				return processResult.result
+			}else{
+				 println "sh result is: null"
+				 return null
+			}
         }
     }
 


### PR DESCRIPTION
Hi,

the modification is made to fix a bug encountered on SUPALIEN-372 issue

>2015-06-12 13:52:12,065 testTopo-Environment.compute [1] INFO [compute-stdout] -       ----------alien.support.BugHostedOnKO-0.1-SNAPSHOT/scripts/preconfNoEcho.sh : bash : Return Code ----------
2015-06-12 13:52:12,065 testTopo-Environment.compute [1] INFO [compute-stdout] -       Return Code : 0
2015-06-12 13:52:12,065 testTopo-Environment.compute [1] INFO [compute-stdout] -       ---------------------------------
2015-06-12 13:52:12,065 testTopo-Environment.compute [1] INFO [compute-stdout] -       
2015-06-12 13:52:12,069 testTopo-Environment.compute [1] INFO [compute-stderr] - Caught: java.lang.NullPointerException: Cannot get property 'result' on null object
2015-06-12 13:52:12,069 testTopo-Environment.compute [1] INFO [compute-stderr] - java.lang.NullPointerException: Cannot get property 'result' on null object
2015-06-12 13:52:12,070 testTopo-Environment.compute [1] INFO [compute-stderr] - 	at CloudifyExecutorUtils.executeScript(CloudifyExecutorUtils.groovy:83)
2015-06-12 13:52:12,070 testTopo-Environment.compute [1] INFO [compute-stderr] - 	at CloudifyExecutorUtils$executeScript.call(Unknown Source)
2015-06-12 13:52:12,070 testTopo-Environment.compute [1] INFO [compute-stderr] - 	at start.run(start.groovy:14)

The problem is due to those ternaries :
```groovy
println "sh result is: "+ processResult != null ? processResult.result:null
return processResult != null ? processResult.result : null 
``` 
whose return is *processResult.result* even if *processResult* is null.

Regards.