### PR TITLE
[SUPALIEN-421] fix: On self healing, deleted directory before mountin…

### DIFF
--- a/src/main/resources/velocity/FormatMountStorage.vm
+++ b/src/main/resources/velocity/FormatMountStorage.vm
@@ -14,7 +14,9 @@ if(context.attributes.thisInstance.volumeCreated) {
 		context.storage.format(device, file_system)
 	}
 }
-
+log.info "deleting <${location}> in case it exists on the node... "
+def ant = new AntBuilder()
+ant.delete(dir:location,failonerror:false)
 println "mounting the attached storage <${device}> to <${location}>... "
 context.storage.mount(device, location)
 


### PR DESCRIPTION
…g BS

On self healing, when cdfy tries to mount the BS, an exception occurs because it tries to create the target location but it already exists.
Deleted the target location before sending the storage.mount command to cdfy
